### PR TITLE
Updated akka-stream version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -73,24 +73,9 @@ inThisBuild(
 
 // Akka
 lazy val akkaStreamLibs = Def.setting {
-  CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, 12)) =>
-      Seq(
-        "com.typesafe.akka" %% "akka-stream" % "2.6.1"
-      )
-    case Some((2, 13)) =>
-      Seq(
-        "com.typesafe.akka" %% "akka-stream" % "2.6.20"
-      )
-    case Some((3, _)) =>
-      // because of the conflicting cross-version suffixes 2.13 vs 3
-      Seq(
-        "com.typesafe.akka" % "akka-stream_2.13" % "2.6.20" exclude ("com.typesafe", "ssl-config-core_2.13"),
-        "com.typesafe" %% "ssl-config-core" % "0.6.1"
-      )
-    case _ =>
-      throw new Exception("Unsupported scala version")
-  }
+  Seq(
+    "com.typesafe.akka" %% "akka-stream" % "2.8.6"
+  )
 }
 
 val loggingLibs = Def.setting {


### PR DESCRIPTION
Fixes #1

Updated the version of `akka-stream` to `2.8.6` for all supported Scala versions (`2.12.18`, `2.13.11`, `3.2.2`). This fixes the issue, where the older `_2.13` version of `akka-stream` clashed in projects that use the `_3` version.